### PR TITLE
initialize action.sa_flags

### DIFF
--- a/glib/gmain.c
+++ b/glib/gmain.c
@@ -4983,6 +4983,7 @@ unref_unix_signal_handler_unlocked (int signum)
       struct sigaction action;
       memset (&action, 0, sizeof (action));
       action.sa_handler = SIG_DFL;
+      action.sa_flags = 0;
       sigemptyset (&action.sa_mask);
       sigaction (signum, &action, NULL);
     }


### PR DESCRIPTION
action.sa_flags should be initialized. I don't know which value fits best but initializing it with zero is better than leaving it unintialized.
