### PR TITLE
Make glib-compile-resources --generate-header use correct suffix (.h)

### DIFF
--- a/gio/glib-compile-resources.c
+++ b/gio/glib-compile-resources.c
@@ -669,6 +669,12 @@ main (int argc, char **argv)
 	    base[strlen(base) - strlen (".gresource")] = 0;
 	  target_basename = g_strconcat (base, ".c", NULL);
 	}
+      else if (generate_header)
+        {
+       	  if (g_str_has_suffix (base, ".gresource"))
+       	    base[strlen(base) - strlen (".gresource")] = 0;
+       	  target_basename = g_strconcat (base, ".h", NULL);
+        }
       else
 	{
 	  if (g_str_has_suffix (base, ".gresource"))


### PR DESCRIPTION
Since --generate-source without --target uses ".c" as the extension for the output file, make --generate-header also use ".h" as extension.