### PR TITLE
Update misleading documentation of g_clear_error function

### DIFF
--- a/glib/gerror.c
+++ b/glib/gerror.c
@@ -664,7 +664,7 @@ g_propagate_error (GError **dest,
  * g_clear_error:
  * @err: a #GError return location
  *
- * If @err is %NULL, does nothing. If @err is non-%NULL,
+ * If @err or *@err is %NULL, does nothing. If @err and *@err is non-%NULL,
  * calls g_error_free() on *@err and sets *@err to %NULL.
  */
 void


### PR DESCRIPTION
It's pretty much well explained in the title and commit itself.