### PR TITLE
Set app_name in fdo notification backend

### DIFF
--- a/gio/gfdonotificationbackend.c
+++ b/gio/gfdonotificationbackend.c
@@ -217,6 +217,7 @@ call_notify (GDBusConnection     *con,
   GVariantBuilder hints_builder;
   GIcon *icon;
   GVariant *parameters;
+  const gchar *app_name;
   const gchar *body;
   guchar urgency;
 
@@ -282,17 +283,18 @@ call_notify (GDBusConnection     *con,
         }
     }
 
+  app_name = g_get_application_name ();
   body = g_notification_get_body (notification);
 
   parameters = g_variant_new ("(susssasa{sv}i)",
-                              "",           /* app name */
+                              app_name ? app_name : "",           /* app name */
                               replace_id,
-                              "",           /* app icon */
+                              "",                                 /* app icon */
                               g_notification_get_title (notification),
                               body ? body : "",
                               &action_builder,
                               &hints_builder,
-                              -1);          /* expire_timeout */
+                              -1);                                /* expire_timeout */
 
   g_dbus_connection_call (con, "org.freedesktop.Notifications", "/org/freedesktop/Notifications",
                           "org.freedesktop.Notifications", "Notify",


### PR DESCRIPTION
Sets app_name parameter to be equal the application name. If there's no name for the application, the app_name will be empty.
