### PR TITLE
Fix build error where minor() and major() cant be resolved

### DIFF
--- a/gio/gdbusmessage.c
+++ b/gio/gdbusmessage.c
@@ -32,6 +32,13 @@
 #include <sys/mkdev.h>
 #elif MAJOR_IN_SYSMACROS
 #include <sys/sysmacros.h>
+#else
+//-----------------------------------------
+// guard against caling minor() and minor() below if not defined (as is the case with on android with crystax ndk..verified with version 10.3.2)
+// note: on some systems (eg android with google ndk) the sys/types.h included above also #includes sys/sysmacros.h
+#define NO_MINOR_MAJOR_MAKEDEV_DEFS_FOUND
+
+//---------------------------------------
 #endif
 
 #include "gdbusutils.h"
@@ -3475,8 +3482,10 @@ g_dbus_message_print (GDBusMessage *message,
               fs = g_string_new (NULL);
               if (fstat (fds[n], &statbuf) == 0)
                 {
+#ifndef NO_MINOR_MAJOR_MAKEDEV_DEFS_FOUND                       
                   g_string_append_printf (fs, "%s" "dev=%d:%d", fs->len > 0 ? "," : "",
                                           major (statbuf.st_dev), minor (statbuf.st_dev));
+#endif                  
                   g_string_append_printf (fs, "%s" "mode=0%o", fs->len > 0 ? "," : "",
                                           statbuf.st_mode);
                   g_string_append_printf (fs, "%s" "ino=%" G_GUINT64_FORMAT, fs->len > 0 ? "," : "",
@@ -3485,8 +3494,10 @@ g_dbus_message_print (GDBusMessage *message,
                                           (guint) statbuf.st_uid);
                   g_string_append_printf (fs, "%s" "gid=%u", fs->len > 0 ? "," : "",
                                           (guint) statbuf.st_gid);
+#ifndef NO_MINOR_MAJOR_MAKEDEV_DEFS_FOUND                     
                   g_string_append_printf (fs, "%s" "rdev=%d:%d", fs->len > 0 ? "," : "",
                                           major (statbuf.st_rdev), minor (statbuf.st_rdev));
+#endif                  
                   g_string_append_printf (fs, "%s" "size=%" G_GUINT64_FORMAT, fs->len > 0 ? "," : "",
                                           (guint64) statbuf.st_size);
                   g_string_append_printf (fs, "%s" "atime=%" G_GUINT64_FORMAT, fs->len > 0 ? "," : "",


### PR DESCRIPTION
Fix build error where functions `minor()` and `major()` are called but have never been defined.
The functions should usually be defined by the inclusion of
`sys/mkdev.h` or `sys/sysmacros.h`

However this inclusion is conditional and can fail.
In fact it probably only succeeds if `types.h` (included further above) happens to include sysmacros.h as happens unconditionally on many systems. (eg android using google's ndk)
