### PR TITLE
Avoid possible double free in g_free_error

### DIFF
--- a/glib/gerror.c
+++ b/glib/gerror.c
@@ -487,8 +487,9 @@ void
 g_error_free (GError *error)
 {
   g_return_if_fail (error != NULL);
-
+  
   g_free (error->message);
+  error->message = NULL;
 
   g_slice_free (GError, error);
 }

--- a/glib/gerror.c
+++ b/glib/gerror.c
@@ -487,7 +487,7 @@ void
 g_error_free (GError *error)
 {
   g_return_if_fail (error != NULL);
-  
+
   g_free (error->message);
   error->message = NULL;
 


### PR DESCRIPTION
Glib user can set "error" variable to NULL after calling g_error_free() to avoid double free in rare scenarios.
However, error->message can be set to NULL inside g_error_free(), this will avoid possible double free problem in glib.