### PR TITLE
Add g_ptr_array_add_array function

### DIFF
--- a/glib/garray.h
+++ b/glib/garray.h
@@ -167,6 +167,10 @@ GPtrArray *g_ptr_array_remove_range       (GPtrArray        *array,
 GLIB_AVAILABLE_IN_ALL
 void       g_ptr_array_add                (GPtrArray        *array,
 					   gpointer          data);
+GLIB_AVAILABLE_IN_ALL
+void       g_ptr_array_add_array          (GPtrArray        *array,
+	 			           gpointer         *data, 
+				           gint             len);
 GLIB_AVAILABLE_IN_2_40
 void       g_ptr_array_insert             (GPtrArray        *array,
                                            gint              index_,


### PR DESCRIPTION
The GPtrArray can only be added row by row, this is not so efficient in some case, need a new function to merge two array quickly.