### PR TITLE
add g_ptr_array_add_array function

### DIFF
--- a/glib/garray.c
+++ b/glib/garray.c
@@ -1394,6 +1394,21 @@ g_ptr_array_add (GPtrArray *array,
   rarray->pdata[rarray->len++] = data;
 }
 
+void
+g_ptr_array_add_array (GPtrArray *array,
+                       gpointer  *data, gint len)
+{
+  gint i=0;
+  GRealPtrArray *rarray = (GRealPtrArray *)array;
+  g_return_if_fail (rarray);
+  g_ptr_array_maybe_expand (rarray, len);
+  
+  for(i=0;i<len;i++)
+  {
+    rarray->pdata[rarray->len++] = data[i];
+  }
+}
+
 /**
  * g_ptr_array_insert:
  * @array: a #GPtrArray


### PR DESCRIPTION
The GPtrArray can only be added row by row, this is not so efficient in some case, need a new function to merge two array quickly.