### PR TITLE
OSX: Use xdgmime system to guess content type from data

### DIFF
--- a/gio/Makefile.am
+++ b/gio/Makefile.am
@@ -3,9 +3,7 @@ include $(top_srcdir)/glib.mk
 SUBDIRS = gdbus-2.0/codegen
 
 if OS_UNIX
-if !OS_COCOA
 SUBDIRS += xdgmime
-endif
 endif
 
 if OS_WIN32_AND_DLL_COMPILATION
@@ -251,10 +249,9 @@ SUBDIRS += fam
 endif
 
 if OS_UNIX
-if !OS_COCOA
 platform_libadd += xdgmime/libxdgmime.la
 platform_deps += xdgmime/libxdgmime.la
-
+if !OS_COCOA
 appinfo_headers += gdesktopappinfo.h
 endif
 


### PR DESCRIPTION
Closes: Bug #788401

The problem is described here:

https://bugzilla.gnome.org/show_bug.cgi?id=788401

This patch introduces the use of the xdgmime system to guess
the content type from data. So you can guess for example the
type public.svg-image from the file content of a svg file.
This patch only applies to MacOS. A test for the regression
is also included.