### PR TITLE
gutf8: Fix null pointer error in g_utf8_validate()

### DIFF
--- a/glib/gutf8.c
+++ b/glib/gutf8.c
@@ -1665,7 +1665,9 @@ g_utf8_validate (const char   *str,
 
 {
   const gchar *p;
-
+  
+  g_return_val_if_fail (str != NULL, FALSE);  
+  
   if (max_len < 0)
     p = fast_validate (str);
   else


### PR DESCRIPTION
We will get a segment fault due to null pointer error when this function calls fast_validate() or fast_validate_len().