### PR TITLE
Fix flags validation

### DIFF
--- a/gobject/genums.c
+++ b/gobject/genums.c
@@ -152,7 +152,10 @@ value_flags_enum_collect_value (GValue      *value,
 				GTypeCValue *collect_values,
 				guint        collect_flags)
 {
-  value->data[0].v_long = collect_values[0].v_int;
+  if (G_VALUE_HOLDS_ENUM (value))
+    value->data[0].v_long = collect_values[0].v_int;
+  else
+    value->data[0].v_long = (guint) collect_values[0].v_int;
 
   return NULL;
 }


### PR DESCRIPTION
gint -> glong conversion brings flags to be invalid if the highest bit is set.
See gobject/gparamspecs.c:param_flags_validate() which triggers the warning in
gobject/gobject.c:object_set_property().