### PR TITLE
fix compile error for AArch64-ILP32

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1327,13 +1327,6 @@ if sizet_size == short_size
   glibconfig_conf.set_quoted('gsize_format', 'hu')
   glibconfig_conf.set_quoted('gssize_format', 'hi')
   glibconfig_conf.set('glib_msize_type', 'SHRT')
-elif sizet_size == int_size
-  glibconfig_conf.set('glib_size_type_define', 'int')
-  glibconfig_conf.set_quoted('gsize_modifier', '')
-  glibconfig_conf.set_quoted('gssize_modifier', '')
-  glibconfig_conf.set_quoted('gsize_format', 'u')
-  glibconfig_conf.set_quoted('gssize_format', 'i')
-  glibconfig_conf.set('glib_msize_type', 'INT')
 elif sizet_size == long_size
   glibconfig_conf.set('glib_size_type_define', 'long')
   glibconfig_conf.set_quoted('gsize_modifier', 'l')
@@ -1341,6 +1334,13 @@ elif sizet_size == long_size
   glibconfig_conf.set_quoted('gsize_format', 'lu')
   glibconfig_conf.set_quoted('gssize_format', 'li')
   glibconfig_conf.set('glib_msize_type', 'LONG')
+elif sizet_size == int_size
+  glibconfig_conf.set('glib_size_type_define', 'int')
+  glibconfig_conf.set_quoted('gsize_modifier', '')
+  glibconfig_conf.set_quoted('gssize_modifier', '')
+  glibconfig_conf.set_quoted('gsize_format', 'u')
+  glibconfig_conf.set_quoted('gssize_format', 'i')
+  glibconfig_conf.set('glib_msize_type', 'INT')
 elif sizet_size == long_long_size
   glibconfig_conf.set('glib_size_type_define', 'long long')
   glibconfig_conf.set_quoted('gsize_modifier', int64_m)


### PR DESCRIPTION
error log:
glib/gslice.c:1529:26: error: format '%u' expects iargument of type
'unsigned int', but argument 4 has type 'size_t {aka long unsigned
int}' [-Werror=format=]

g_fprintf (stderr, "GSlice: MemChecker: attempt to release
non-allocated block: %p size=%" G_GSIZE_FORMAT "\n", pointer, size);
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

In file included from glib/gslice.c:20:0:
glib/glibconfig.h:81:25: note: format string is defined here
 #define G_GSIZE_FORMAT "u"

Signed-off-by: zhuyan <zhuyan34@huawei.com>