### PR TITLE
meson: Exclude gosxutils.m when building for iOS

### DIFF
--- a/glib/meson.build
+++ b/glib/meson.build
@@ -316,7 +316,7 @@ else
   platform_deps = []
 endif
 
-if host_system == 'darwin'
+if glib_have_cocoa
   glib_sources += files('gosxutils.m')
 endif
 


### PR DESCRIPTION
For ios, the Cocoa header file does not exist, which causes compilation errors