### PR TITLE
Update supperssion for g_object_new()

### DIFF
--- a/glib.supp
+++ b/glib.supp
@@ -793,6 +793,26 @@
 	fun:g_object_new_valist
 }
 
+# False positive
+{
+	g_object_new
+	Memcheck:Leak
+	match-leak-kinds:reachable,possible
+	...
+	fun:g_type_class_ref
+	fun:g_object_new_with_properties
+	fun:g_object_new
+}
+
+{
+	_dl_init
+	Memcheck:Leak
+	match-leak-kinds:reachable,possible
+	...
+	fun:call_init
+	fun:_dl_init
+}
+
 # g_set_user_dirs() deliberately leaks the previous cached g_get_user_*() values.
 # These will not all be reachable on exit.
 {


### PR DESCRIPTION
I've been testing the glib json functions using valgrind for this basic code: 
```
#include <stdio.h>
#include <json-glib/json-glib.h>

int main(int argc, char **argv) {
	JsonBuilder *builder = json_builder_new ();

	json_builder_begin_object(builder);
	json_builder_set_member_name(builder, "server");
	json_builder_add_string_value(builder, "server_value");
	json_builder_end_object(builder);

        JsonGenerator *gen = json_generator_new ();
        JsonNode *root = json_builder_get_root (builder);

        json_generator_set_root (gen, root);
        gchar* result = json_generator_to_data (gen, NULL);
	printf ("json: %s\n", result);

	g_free(result);
        json_node_free (root);
        g_object_unref (gen);
        g_object_unref (builder);

	return 0;
}
```

Got a lot of valgrind warnings like this:
```
==23599== 8 bytes in 1 blocks are still reachable in loss record 8 of 281
==23599==    at 0x4835753: malloc (vg_replace_malloc.c:307)
==23599==    by 0x4AE48D0: g_malloc (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5800.3)
==23599==    by 0x4AFE4BB: g_memdup (in /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0.5800.3)
==23599==    by 0x4A63899: g_signal_newv (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5800.3)
==23599==    by 0x4A643F3: g_signal_new_valist (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5800.3)
==23599==    by 0x4A644DD: g_signal_new (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5800.3)
==23599==    by 0x4A50F3D: ??? (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5800.3)
==23599==    by 0x4A6E1DA: g_type_class_ref (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5800.3)
==23599==    by 0x4A6E37F: g_type_class_ref (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5800.3)
==23599==    by 0x4A53CE7: g_object_new_with_properties (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5800.3)
==23599==    by 0x4A54730: g_object_new (in /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0.5800.3)
==23599==    by 0x109208: main (glib_test_json.c:5)
==23599==
```

I've updated glib.supp for this also suppressing other "_dl_init" valgrind warnings.