### PR TITLE
Fix g_settings_schema_has_key

### DIFF
--- a/gio/gsettingsschema.c
+++ b/gio/gsettingsschema.c
@@ -1055,7 +1055,16 @@ gboolean
 g_settings_schema_has_key (GSettingsSchema *schema,
                            const gchar     *key)
 {
-  return gvdb_table_has_value (schema->table, key);
+  GSettingsSchema *s;
+
+  if(gvdb_table_has_value (schema->table, key))
+    return TRUE;
+
+  for (s = schema; s; s = s->extends)
+    if(gvdb_table_has_value (s->table, key))
+      return TRUE;
+
+  return FALSE;
 }
 
 /**

--- a/gio/tests/gsettings.c
+++ b/gio/tests/gsettings.c
@@ -3248,6 +3248,21 @@ test_extended_schema (void)
   g_settings_schema_unref (schema);
 }
 
+static void
+test_extended_schema_has_key(void)
+{
+  GSettingsSchema *schema;
+  GSettings *settings;
+
+  settings = g_settings_new_with_path ("org.gtk.test.extends.extended", "/test/extendes/");
+  g_object_get (settings, "settings-schema", &schema, NULL);
+  g_assert_true (g_settings_schema_has_key (schema, "int32"));
+  g_assert_true (g_settings_schema_has_key (schema, "string"));
+  g_assert_true (g_settings_schema_has_key (schema, "another-int32"));
+  g_object_unref (settings);
+  g_settings_schema_unref (schema);
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -3429,6 +3444,7 @@ main (int argc, char *argv[])
   g_test_add_func ("/gsettings/memory-backend", test_memory_backend);
   g_test_add_func ("/gsettings/read-descriptions", test_read_descriptions);
   g_test_add_func ("/gsettings/test-extended-schema", test_extended_schema);
+  g_test_add_func ("/gsettings/test-extended-schema-has-key", test_extended_schema_has_key);
   g_test_add_func ("/gsettings/default-value", test_default_value);
   g_test_add_func ("/gsettings/per-desktop", test_per_desktop);
   g_test_add_func ("/gsettings/per-desktop/subprocess", test_per_desktop_subprocess);


### PR DESCRIPTION
`g_settings_schema_has_key` checks if schema has a key with a given name.

If the schema extends another, it does not check if a key with the given name exists in the extended schema. This is inconsistent with the behavior of `g_settings_schema_list_keys`, which also includes those.

This PR fixes `has_key` and includes a unit test.