### PR TITLE
gio: Add G_MOUNT_MOUNT_READ_ONLY flag for read-only mounts

### DIFF
--- a/gio/gio-tool-mount.c
+++ b/gio/gio-tool-mount.c
@@ -48,6 +48,7 @@ static gboolean mount_unmount = FALSE;
 static gboolean mount_eject = FALSE;
 static gboolean force = FALSE;
 static gboolean anonymous = FALSE;
+static gboolean mount_readonly = FALSE;
 static gboolean mount_list = FALSE;
 static gboolean extra_detail = FALSE;
 static gboolean mount_monitor = FALSE;
@@ -70,6 +71,7 @@ static const GOptionEntry entries[] =
   { "unmount-scheme", 's', 0, G_OPTION_ARG_STRING, &unmount_scheme, N_("Unmount all mounts with the given scheme"), N_("SCHEME") },
   { "force", 'f', 0, G_OPTION_ARG_NONE, &force, N_("Ignore outstanding file operations when unmounting or ejecting"), NULL },
   { "anonymous", 'a', 0, G_OPTION_ARG_NONE, &anonymous, N_("Use an anonymous user when authenticating"), NULL },
+  { "read-only", 'r', 0, G_OPTION_ARG_NONE, &mount_readonly, N_("Mount read-only"), NULL },
   /* Translator: List here is a verb as in 'List all mounts' */
   { "list", 'l', 0, G_OPTION_ARG_NONE, &mount_list, N_("List user-interesting volumes, drives and mounts"), NULL},
   { "monitor", 'o', 0, G_OPTION_ARG_NONE, &mount_monitor, N_("Monitor user-interesting volume, drive and mount events"), NULL},
@@ -1030,7 +1032,7 @@ mount_with_id (const char *id)
           op = new_mount_op ();
 
           g_volume_mount (volume,
-                          G_MOUNT_MOUNT_NONE,
+                          mount_readonly ? G_MOUNT_MOUNT_READ_ONLY : G_MOUNT_MOUNT_NONE,
                           op,
                           NULL,
                           mount_with_device_file_cb,

--- a/gio/gioenums.h
+++ b/gio/gioenums.h
@@ -244,11 +244,14 @@ typedef enum {
 /**
  * GMountMountFlags:
  * @G_MOUNT_MOUNT_NONE: No flags set.
+ * @G_MOUNT_MOUNT_READ_ONLY: Mount the volume read-only.
+ *   Since: 2.88
  *
  * Flags used when mounting a mount.
  */
 typedef enum /*< flags >*/ {
-  G_MOUNT_MOUNT_NONE = 0
+  G_MOUNT_MOUNT_NONE = 0,
+  G_MOUNT_MOUNT_READ_ONLY = (1 << 0)
 } G_GNUC_FLAG_ENUM GMountMountFlags;
 
 


### PR DESCRIPTION
Add a new flag to `GMountMountFlags` that allows callers to request a read-only mount. This is needed by file managers (e.g. Thunar) to allow users to mount removable drives as read-only.

The flag is passed through the `GVolumeIface::mount_fn` vfunc and can be handled by volume monitor implementations (e.g. gvfs udisks2) to pass the appropriate options to the underlying mount mechanism.

Also add a `--read-only` / `-r` option to the `gio mount` CLI tool.

Enables: https://github.com/GNOME/gvfs/pull/2 (udisks2 read-only mount support)
Enables: https://gitlab.xfce.org/xfce/thunar/-/merge_requests/792 (Thunar 'Mount Read-Only' action)

See https://gitlab.xfce.org/xfce/thunar/-/work_items/867

couldn't fork glib on gitlab.gnome.org , so filing pr here instead